### PR TITLE
Added Test Suite for GraphQL

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken')
+const { AuthenticationError } = require('apollo-server')
 const { models } = require('./db')
 const secret = 'catpack'
 
@@ -31,7 +32,7 @@ const getUserFromToken = (token) => {
  */
 const authenticated = (next) => (root, args, context, info) => {
   if (!context.user) {
-    throw new Error('User not authenticated')
+    throw new AuthenticationError('User not authenticated')
   }
   return next(root, args, context, info)
 }
@@ -44,7 +45,9 @@ const authenticated = (next) => (root, args, context, info) => {
  */
 const authorized = (role, next) => (root, args, context, info) => {
   if (context.user.role !== role) {
-    throw new Error('User is not authorized to perform this action')
+    throw new AuthenticationError(
+      'User is not authorized to perform this action'
+    )
   }
   return next(root, args, context, info)
 }

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,4 +1,4 @@
-const { PubSub } = require('apollo-server')
+const { PubSub, AuthenticationError } = require('apollo-server')
 const { authenticated, authorized } = require('./auth')
 const NEW_POST = 'NEW_POST'
 const pubsub = new PubSub()
@@ -59,7 +59,7 @@ module.exports = {
       const existing = models.User.findOne({ email: input.email })
 
       if (existing) {
-        throw new Error('nope')
+        throw new AuthenticationError('Email ID already exists')
       }
       const user = models.User.createOne({
         ...input,
@@ -73,7 +73,7 @@ module.exports = {
       const user = models.User.findOne(input)
 
       if (!user) {
-        throw new Error('nope')
+        throw new AuthenticationError('EmailID or Password is invalid')
       }
 
       const token = createToken(user)

--- a/tests/__snapshots__/mutation.test.js.snap
+++ b/tests/__snapshots__/mutation.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Mutation CreatePost 1`] = `
+Object {
+  "data": Object {
+    "createPost": Object {
+      "message": "Hello World",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;

--- a/tests/mutation.test.js
+++ b/tests/mutation.test.js
@@ -1,0 +1,59 @@
+const gql = require('graphql-tag')
+const createTestServer = require('./helper')
+const CREATE_POST = gql`
+  mutation {
+    createPost(input: { message: "hello" }) {
+      message
+    }
+  }
+`
+
+const UPDATE_SETTING = gql`
+  mutation {
+    updateSettings(input: { theme: DARK }) {
+      id
+      theme
+    }
+  }
+`
+
+describe('Mutation', () => {
+  test('CreatePost', async () => {
+    const { mutate } = createTestServer({
+      user: { id: 1 },
+      models: {
+        Post: {
+          createOne: jest.fn(() => [
+            {
+              id: 1,
+              message: 'hello',
+              createdAt: 12345839,
+              likes: 20,
+              views: 300,
+            },
+          ]),
+        },
+      },
+    })
+
+    const res = await mutate({ query: CREATE_POST })
+    expect(res).toMatchSnapshot()
+  })
+  test('UpdateSettings', async () => {
+    const { mutate } = createTestServer({
+      user: { id: 1 },
+      models: {
+        Settings: {
+          updateOne(_, input) {
+            return {
+              id: 1,
+              ...input,
+            }
+          },
+        },
+      },
+    })
+    const res = await mutate({ query: UPDATE_SETTING })
+    expect(res.data.updateSettings).toEqual({ id: '1', theme: 'DARK' })
+  })
+})

--- a/tests/resolver.test.js
+++ b/tests/resolver.test.js
@@ -1,0 +1,15 @@
+const resolvers = require('./../src/resolvers')
+
+describe('Resolver Unit Testing', () => {
+  test('Feed', () => {
+    const models = {
+      Post: {
+        findMany: jest.fn(() => ['hello', 'world']),
+      },
+    }
+    expect(resolvers.Query.feed(null, null, { models })).toEqual([
+      'hello',
+      'world',
+    ])
+  })
+})


### PR DESCRIPTION
## Error handling

Any error can be thrown in the Apollo Server and it will not crash the server but It will send the error to the client.  There is a lot of basic error which implements the ApolloError Class like AuthenticationError, UserInputError. We can create our own by extending the ApolloError class. The default error information is really detail contains the error type, resolver path, and the stack trace if the server is running in development mode. 

We can format the error before sending it to the client. It is given as the parameter while creating the ApolloServer. This is the right place if we are using any Error monitoring systems like Sentry. 

## Testing

1. Resolvers
    1. Unit test resolver functions
    2. Mock out data sources
    3. Mock out DB calls
2. Schema
    1. Convert TypeDefs into Schema (using gql)
    2. Unit test Object Types
3. Server
    1. Integration testing the whole server
    2. Create the test client to use to issue queries and mutations with against a testing instance of your server
    3. Mock out variables, context, data sources